### PR TITLE
fix: prevent nil

### DIFF
--- a/lua/sidebar-nvim.lua
+++ b/lua/sidebar-nvim.lua
@@ -88,7 +88,7 @@ end
 
 function M.reset_highlight()
     colors.setup()
-    renderer.render_hl(view.View.bufnr)
+    renderer.render_hl(view.View.bufnr, {})
 end
 
 function M._on_cursor_move(direction) lib.on_cursor_move(direction) end


### PR DESCRIPTION
Error when `lua require("sidebar-nvim").reset_highlight()`

Error message:
```Error executing lua ...ck/packer/opt/sidebar.nvim/lua/sidebar-nvim/renderer.lua:112: bad argument #1 to 'ipairs' (table expected, got nil)```